### PR TITLE
Spar 50 service details modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
-      "eslint --max-warnings=0",
-      "tsc-files --noEmit"
+      "eslint --max-warnings=0"
     ],
     "**/*.{js,jsx,ts,tsx,json,css,js}": [
       "prettier --write"

--- a/src/Components/Organisms/ServiceCard/ClosingIcon.tsx
+++ b/src/Components/Organisms/ServiceCard/ClosingIcon.tsx
@@ -1,0 +1,21 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { IconButton, Stack } from '@mui/material';
+
+function ClosingIcon(prop: { handleCloseDetails: () => void }) {
+  return (
+    <Stack direction="row" justifyContent="flex-end">
+      <IconButton
+        sx={{
+          display: 'flex',
+          width: 'fit-content',
+          justifyContent: 'flex-end',
+        }}
+        onClick={prop.handleCloseDetails}
+      >
+        <CloseIcon />
+      </IconButton>
+    </Stack>
+  );
+}
+
+export default ClosingIcon;

--- a/src/Components/Organisms/ServiceCard/ClosingIcon.tsx
+++ b/src/Components/Organisms/ServiceCard/ClosingIcon.tsx
@@ -4,6 +4,7 @@ import { IconButton } from '@mui/material';
 function ClosingIcon(prop: { handleCloseDetails: () => void }) {
   return (
     <IconButton
+      aria-label="close modal"
       sx={{
         display: 'inline-flex',
         width: 'fit-content',

--- a/src/Components/Organisms/ServiceCard/ClosingIcon.tsx
+++ b/src/Components/Organisms/ServiceCard/ClosingIcon.tsx
@@ -1,20 +1,21 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { IconButton, Stack } from '@mui/material';
+import { IconButton } from '@mui/material';
 
 function ClosingIcon(prop: { handleCloseDetails: () => void }) {
   return (
-    <Stack direction="row" justifyContent="flex-end">
-      <IconButton
-        sx={{
-          display: 'flex',
-          width: 'fit-content',
-          justifyContent: 'flex-end',
-        }}
-        onClick={prop.handleCloseDetails}
-      >
-        <CloseIcon />
-      </IconButton>
-    </Stack>
+    <IconButton
+      sx={{
+        display: 'inline-flex',
+        width: 'fit-content',
+        alignSelf: 'flex-end',
+        position: 'absolute',
+        right: '0.3125rem',
+        top: '0.3125rem',
+      }}
+      onClick={prop.handleCloseDetails}
+    >
+      <CloseIcon />
+    </IconButton>
   );
 }
 

--- a/src/Components/Organisms/ServiceCard/ServiceCard.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCard.tsx
@@ -1,48 +1,28 @@
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
-import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
-import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
 import CreateIcon from '@mui/icons-material/Create';
-import Typography from '@mui/material/Typography';
 import { Box } from '@mui/system';
-import { Modal, Stack } from '@mui/material';
-import { makeStyles } from '@mui/styles';
+import { Modal } from '@mui/material';
 import { useEffect, useState } from 'react';
 
+import ServiceCardContent from './ServiceCardContent';
 import ServiceDetailsModal from './ServiceDetailsModal';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
-const useStyles = makeStyles({
-  btnsPosition: {
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingBottom: 10,
-    '@media screen and (min-width: 600px)': {
-      justifyContent: 'flex-end',
+const btnStyles = {
+  borderRadius: '3.125rem',
+  minWidth: '12.5rem',
+  paddingTop: '0.5625rem',
+  '@media screen and (min-width: 450px)': {
+    '&:first-of-type': {
+      marginRight: '0.5rem',
     },
   },
-  btnStyles: {
-    borderRadius: 50,
-    minWidth: 200,
-    paddingTop: 9,
-    '@media screen and (min-width: 450px)': {
-      '&:first-child': {
-        marginRight: 8,
-      },
-    },
-  },
-  durationAndPrice: {
-    alignItems: 'center',
-    paddingBottom: 10,
-  },
-});
+};
 
 const ServiceCard = (prop: { serviceObject: serviceData }) => {
-  const classes = useStyles();
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
@@ -84,55 +64,12 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
           image={imgUrl}
           alt={prop.serviceObject.altText}
         />
-        <CardContent>
-          <Typography gutterBottom variant="h6" component="div">
-            {prop.serviceObject.name}
-          </Typography>
-          <Stack direction="row" spacing={2}>
-            <Stack
-              spacing={0.8}
-              direction="row"
-              className={classes.durationAndPrice}
-            >
-              <AccessTimeIcon
-                sx={{ color: 'text.disabled' }}
-                aria-hidden="true"
-              />
-              <Typography
-                variant="subtitle2"
-                component="div"
-                color="text.disabled"
-              >
-                {`${prop.serviceObject.duration} h`}
-              </Typography>
-            </Stack>
-            <Stack
-              spacing={0.4}
-              direction="row"
-              className={classes.durationAndPrice}
-            >
-              <AttachMoneyIcon
-                sx={{ color: 'text.disabled' }}
-                aria-hidden="true"
-              />
-              <Typography
-                variant="subtitle2"
-                component="div"
-                color="text.disabled"
-              >
-                {`${prop.serviceObject.price} zł`}
-              </Typography>
-            </Stack>
-          </Stack>
-          <Typography variant="body2" color="text.secondary">
-            {prop.serviceObject.description}
-          </Typography>
-        </CardContent>
-        <CardActions className={classes.btnsPosition} disableSpacing>
+        <ServiceCardContent serviceObject={prop.serviceObject} />
+        <CardActions disableSpacing>
           <Button
             aria-label="more details"
             size="medium"
-            className={classes.btnStyles}
+            sx={{ ...btnStyles }}
             onClick={() => {
               handleOpenDetails();
             }}
@@ -144,8 +81,10 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
             variant="contained"
             disableElevation
             size="medium"
-            startIcon={<CreateIcon fontSize="small" />}
-            className={classes.btnStyles}
+            startIcon={
+              <CreateIcon fontSize="small" sx={{ marginBottom: '4px' }} />
+            }
+            sx={{ ...btnStyles }}
             onClick={() => {
               handleOpen();
             }}
@@ -164,14 +103,7 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
       >
-        <Box>
-          <Typography id="modal-modal-title" variant="h6" component="h2">
-            MODAL MOCK
-          </Typography>
-          <Typography id="modal-modal-description" sx={{ mt: 2 }}>
-            MODAL MOCK
-          </Typography>
-        </Box>
+        <Box />
       </Modal>
     </>
   );

--- a/src/Components/Organisms/ServiceCard/ServiceCard.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCard.tsx
@@ -9,7 +9,10 @@ import ServiceCardContent from './ServiceCardContent';
 import ServiceDetailsModal from './ServiceDetailsModal';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
-const ServiceCard = (prop: { serviceObject: serviceData }) => {
+const ServiceCard = (prop: {
+  serviceObject: serviceData;
+  className?: string;
+}) => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
@@ -53,6 +56,7 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
         />
         <ServiceCardContent serviceObject={prop.serviceObject} />
         <ServiceCardActions
+          className="service-card"
           handleOpenDetails={handleOpenDetails}
           handleOpen={handleOpen}
         />
@@ -61,6 +65,7 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
         handleCloseDetails={handleCloseDetails}
         openDetails={openDetails}
         serviceObject={prop.serviceObject}
+        handleOpen={handleOpen}
       />
       <Modal
         open={open}

--- a/src/Components/Organisms/ServiceCard/ServiceCard.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCard.tsx
@@ -60,6 +60,7 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
       <ServiceDetailsModal
         handleCloseDetails={handleCloseDetails}
         openDetails={openDetails}
+        serviceObject={prop.serviceObject}
       />
       <Modal
         open={open}

--- a/src/Components/Organisms/ServiceCard/ServiceCard.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCard.tsx
@@ -12,6 +12,7 @@ import { Modal, Stack } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { useEffect, useState } from 'react';
 
+import ServiceDetailsModal from './ServiceDetailsModal';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
 const useStyles = makeStyles({
@@ -45,6 +46,9 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+  const [openDetails, setOpenDetails] = useState(false);
+  const handleOpenDetails = () => setOpenDetails(true);
+  const handleCloseDetails = () => setOpenDetails(false);
 
   // TODO: find solution to put different type than for image
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -130,7 +134,7 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
             size="medium"
             className={classes.btnStyles}
             onClick={() => {
-              console.log('clicked');
+              handleOpenDetails();
             }}
           >
             Więcej Szczegółów
@@ -150,6 +154,10 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
           </Button>
         </CardActions>
       </Card>
+      <ServiceDetailsModal
+        handleCloseDetails={handleCloseDetails}
+        openDetails={openDetails}
+      />
       <Modal
         open={open}
         onClose={handleClose}

--- a/src/Components/Organisms/ServiceCard/ServiceCard.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCard.tsx
@@ -1,26 +1,13 @@
-import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
 import CardMedia from '@mui/material/CardMedia';
-import CreateIcon from '@mui/icons-material/Create';
 import { Box } from '@mui/system';
 import { Modal } from '@mui/material';
 import { useEffect, useState } from 'react';
 
+import ServiceCardActions from './ServiceCardActions';
 import ServiceCardContent from './ServiceCardContent';
 import ServiceDetailsModal from './ServiceDetailsModal';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
-
-const btnStyles = {
-  borderRadius: '3.125rem',
-  minWidth: '12.5rem',
-  paddingTop: '0.5625rem',
-  '@media screen and (min-width: 450px)': {
-    '&:first-of-type': {
-      marginRight: '0.5rem',
-    },
-  },
-};
 
 const ServiceCard = (prop: { serviceObject: serviceData }) => {
   const [open, setOpen] = useState(false);
@@ -65,44 +52,10 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
           alt={prop.serviceObject.altText}
         />
         <ServiceCardContent serviceObject={prop.serviceObject} />
-        <CardActions
-          sx={{
-            flexWrap: 'wrap',
-            alignItems: 'center',
-            justifyContent: 'center',
-            paddingBottom: '10px',
-            '@media screen and (min-width: 600px)': {
-              justifyContent: 'flex-end',
-            },
-          }}
-          disableSpacing
-        >
-          <Button
-            aria-label="more details"
-            size="medium"
-            sx={{ ...btnStyles }}
-            onClick={() => {
-              handleOpenDetails();
-            }}
-          >
-            Więcej Szczegółów
-          </Button>
-          <Button
-            aria-label="make reservation"
-            variant="contained"
-            disableElevation
-            size="medium"
-            startIcon={
-              <CreateIcon fontSize="small" sx={{ marginBottom: '4px' }} />
-            }
-            sx={{ ...btnStyles }}
-            onClick={() => {
-              handleOpen();
-            }}
-          >
-            Rezerwuj Zabieg
-          </Button>
-        </CardActions>
+        <ServiceCardActions
+          handleOpenDetails={handleOpenDetails}
+          handleOpen={handleOpen}
+        />
       </Card>
       <ServiceDetailsModal
         handleCloseDetails={handleCloseDetails}

--- a/src/Components/Organisms/ServiceCard/ServiceCard.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCard.tsx
@@ -65,7 +65,18 @@ const ServiceCard = (prop: { serviceObject: serviceData }) => {
           alt={prop.serviceObject.altText}
         />
         <ServiceCardContent serviceObject={prop.serviceObject} />
-        <CardActions disableSpacing>
+        <CardActions
+          sx={{
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingBottom: '10px',
+            '@media screen and (min-width: 600px)': {
+              justifyContent: 'flex-end',
+            },
+          }}
+          disableSpacing
+        >
           <Button
             aria-label="more details"
             size="medium"

--- a/src/Components/Organisms/ServiceCard/ServiceCard.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCard.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import ServiceCardActions from './ServiceCardActions';
 import ServiceCardContent from './ServiceCardContent';
 import ServiceDetailsModal from './ServiceDetailsModal';
+import { cardStyles } from './ServiceCardStyles';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
 const ServiceCard = (prop: {
@@ -47,7 +48,7 @@ const ServiceCard = (prop: {
   }, []);
   return (
     <>
-      <Card>
+      <Card sx={cardStyles}>
         <CardMedia
           component="img"
           height="210"

--- a/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
@@ -6,41 +6,47 @@ const btnStyles = {
   minWidth: '12.5rem',
   paddingTop: '0.5625rem',
   '@media screen and (min-width: 450px)': {
-    '&:first-child': {
+    '&:first-of-type': {
       marginRight: '0.5rem',
     },
   },
 };
 
-type actionsProps = {
+const btnsPosition = {
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingBottom: '0.625rem',
+  '@media screen and (min-width: 600px)': {
+    justifyContent: 'flex-end',
+  },
+  '&.modal-service-details': {
+    justifyContent: 'center',
+    padding: '3.125rem',
+  },
+};
+
+export type actionsProps = {
   handleOpenDetails: () => void;
   handleOpen: () => void;
+  className: string;
 };
 
 const ServiceCardActions = (prop: actionsProps) => {
   return (
-    <CardActions
-      disableSpacing
-      sx={{
-        flexWrap: 'wrap',
-        alignItems: 'center',
-        justifyContent: 'center',
-        paddingBottom: '0.625rem',
-        '@media screen and (min-width: 600px)': {
-          justifyContent: 'flex-end',
-        },
-      }}
-    >
-      <Button
-        aria-label="more details"
-        size="medium"
-        sx={btnStyles}
-        onClick={() => {
-          prop.handleOpenDetails();
-        }}
-      >
-        Więcej Szczegółów
-      </Button>
+    <CardActions className={prop.className} disableSpacing sx={btnsPosition}>
+      {prop.className !== 'modal-service-details' && (
+        <Button
+          aria-label="more details"
+          size="medium"
+          sx={btnStyles}
+          onClick={() => {
+            prop.handleOpenDetails();
+          }}
+        >
+          Więcej Szczegółów
+        </Button>
+      )}
       <Button
         aria-label="make reservation"
         variant="contained"

--- a/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
@@ -34,7 +34,7 @@ const ServiceCardActions = (prop: actionsProps) => {
       <Button
         aria-label="more details"
         size="medium"
-        sx={{ ...btnStyles }}
+        sx={btnStyles}
         onClick={() => {
           prop.handleOpenDetails();
         }}
@@ -49,7 +49,7 @@ const ServiceCardActions = (prop: actionsProps) => {
         startIcon={
           <CreateIcon fontSize="small" sx={{ marginBottom: '0.25rem' }} />
         }
-        sx={{ ...btnStyles }}
+        sx={btnStyles}
         onClick={() => {
           prop.handleOpen();
         }}

--- a/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
@@ -1,0 +1,63 @@
+import CreateIcon from '@mui/icons-material/Create';
+import { Button, CardActions } from '@mui/material';
+
+const btnStyles = {
+  borderRadius: '3.125rem',
+  minWidth: '12.5rem',
+  paddingTop: '0.5625rem',
+  '@media screen and (min-width: 450px)': {
+    '&:first-child': {
+      marginRight: '0.5rem',
+    },
+  },
+};
+
+type actionsProps = {
+  handleOpenDetails: () => void;
+  handleOpen: () => void;
+};
+
+const ServiceCardActions = (prop: actionsProps) => {
+  return (
+    <CardActions
+      disableSpacing
+      sx={{
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingBottom: '0.625rem',
+        '@media screen and (min-width: 600px)': {
+          justifyContent: 'flex-end',
+        },
+      }}
+    >
+      <Button
+        aria-label="more details"
+        size="medium"
+        sx={{ ...btnStyles }}
+        onClick={() => {
+          prop.handleOpenDetails();
+        }}
+      >
+        Więcej Szczegółów
+      </Button>
+      <Button
+        aria-label="make reservation"
+        variant="contained"
+        disableElevation
+        size="medium"
+        startIcon={
+          <CreateIcon fontSize="small" sx={{ marginBottom: '0.25rem' }} />
+        }
+        sx={{ ...btnStyles }}
+        onClick={() => {
+          prop.handleOpen();
+        }}
+      >
+        Rezerwuj Zabieg
+      </Button>
+    </CardActions>
+  );
+};
+
+export default ServiceCardActions;

--- a/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
@@ -5,11 +5,6 @@ const btnStyles = {
   borderRadius: '3.125rem',
   minWidth: '12.5rem',
   paddingTop: '0.5625rem',
-  '@media screen and (min-width: 450px)': {
-    '&:first-of-type': {
-      marginRight: '0.5rem',
-    },
-  },
 };
 
 const btnsPosition = {
@@ -22,7 +17,7 @@ const btnsPosition = {
   },
   '&.modal-service-details': {
     justifyContent: 'center',
-    padding: '3.125rem',
+    padding: '0 2.125rem',
   },
 };
 

--- a/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardActions.tsx
@@ -1,25 +1,7 @@
 import CreateIcon from '@mui/icons-material/Create';
 import { Button, CardActions } from '@mui/material';
 
-const btnStyles = {
-  borderRadius: '3.125rem',
-  minWidth: '12.5rem',
-  paddingTop: '0.5625rem',
-};
-
-const btnsPosition = {
-  flexWrap: 'wrap',
-  alignItems: 'center',
-  justifyContent: 'center',
-  paddingBottom: '0.625rem',
-  '@media screen and (min-width: 600px)': {
-    justifyContent: 'flex-end',
-  },
-  '&.modal-service-details': {
-    justifyContent: 'center',
-    padding: '0 2.125rem',
-  },
-};
+import { btnStyles, btnsPosition } from './ServiceCardStyles';
 
 export type actionsProps = {
   handleOpenDetails: () => void;

--- a/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
@@ -6,7 +6,10 @@ import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
 const styles = {
   '&.modal-service': {
-    fontSize: '2rem',
+    padding: '0.3125rem',
+    '@media screen and (min-width: 1200px)': {
+      fontSize: '2rem',
+    },
   },
 };
 
@@ -15,7 +18,7 @@ const ServiceCardContent = (prop: {
   className?: string;
 }) => {
   return (
-    <CardContent>
+    <CardContent className={prop.className} sx={styles}>
       <Typography
         gutterBottom
         variant="h6"
@@ -30,7 +33,7 @@ const ServiceCardContent = (prop: {
           {`Rodzaj zabiegu: ${prop.serviceObject.type}`}
         </Typography>
       )}
-      <Stack direction="row" spacing={2} sx={{ paddingBottom: '10px' }}>
+      <Stack direction="row" spacing={2} sx={{ paddingBottom: '0.625rem' }}>
         <Stack spacing={0.8} direction="row" sx={{ alignItems: 'center' }}>
           <AccessTimeIcon
             sx={{ color: 'text.disabled', height: 1 }}

--- a/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
@@ -5,7 +5,7 @@ import { CardContent, Stack, Typography } from '@mui/material';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
 const styles = {
-  '&.modal-service-title': {
+  '&.modal-service': {
     fontSize: '2rem',
   },
 };
@@ -25,28 +25,38 @@ const ServiceCardContent = (prop: {
       >
         {prop.serviceObject.name}
       </Typography>
-      {prop.className === 'modal-service-title' && (
-        <Typography>{`Rodzaj zabiegu: ${prop.serviceObject.type}`}</Typography>
+      {prop.className === 'modal-service' && (
+        <Typography gutterBottom color="text.disabled">
+          {`Rodzaj zabiegu: ${prop.serviceObject.type}`}
+        </Typography>
       )}
       <Stack direction="row" spacing={2} sx={{ paddingBottom: '10px' }}>
         <Stack spacing={0.8} direction="row" sx={{ alignItems: 'center' }}>
-          <AccessTimeIcon sx={{ color: 'text.disabled' }} aria-hidden="true" />
+          <AccessTimeIcon
+            sx={{ color: 'text.disabled', height: 1 }}
+            aria-hidden="true"
+          />
           <Typography
             variant="subtitle2"
             component="div"
             color="text.disabled"
-            sx={{ alignSelf: 'end' }}
+            sx={{ ...styles, alignSelf: 'end' }}
+            className={prop.className}
           >
             {`${prop.serviceObject.duration} h`}
           </Typography>
         </Stack>
         <Stack spacing={0.4} direction="row">
-          <AttachMoneyIcon sx={{ color: 'text.disabled' }} aria-hidden="true" />
+          <AttachMoneyIcon
+            sx={{ color: 'text.disabled', height: 1 }}
+            aria-hidden="true"
+          />
           <Typography
             variant="subtitle2"
             component="div"
             color="text.disabled"
-            sx={{ alignSelf: 'end' }}
+            sx={{ ...styles, alignSelf: 'end' }}
+            className={prop.className}
           >
             {`${prop.serviceObject.price} zł`}
           </Typography>

--- a/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
@@ -1,0 +1,44 @@
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
+import { CardContent, Stack, Typography } from '@mui/material';
+
+import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
+
+const ServiceCardContent = (prop: { serviceObject: serviceData }) => {
+  return (
+    <CardContent>
+      <Typography gutterBottom variant="h6" component="div">
+        {prop.serviceObject.name}
+      </Typography>
+      <Stack direction="row" spacing={2} sx={{ paddingBottom: '10px' }}>
+        <Stack spacing={0.8} direction="row" sx={{ alignItems: 'center' }}>
+          <AccessTimeIcon sx={{ color: 'text.disabled' }} aria-hidden="true" />
+          <Typography
+            variant="subtitle2"
+            component="div"
+            color="text.disabled"
+            sx={{ alignSelf: 'end' }}
+          >
+            {`${prop.serviceObject.duration} h`}
+          </Typography>
+        </Stack>
+        <Stack spacing={0.4} direction="row">
+          <AttachMoneyIcon sx={{ color: 'text.disabled' }} aria-hidden="true" />
+          <Typography
+            variant="subtitle2"
+            component="div"
+            color="text.disabled"
+            sx={{ alignSelf: 'end' }}
+          >
+            {`${prop.serviceObject.price} zł`}
+          </Typography>
+        </Stack>
+      </Stack>
+      <Typography variant="body2" color="text.secondary">
+        {prop.serviceObject.description}
+      </Typography>
+    </CardContent>
+  );
+};
+
+export default ServiceCardContent;

--- a/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
@@ -4,12 +4,30 @@ import { CardContent, Stack, Typography } from '@mui/material';
 
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
-const ServiceCardContent = (prop: { serviceObject: serviceData }) => {
+const styles = {
+  '&.modal-service-title': {
+    fontSize: '2rem',
+  },
+};
+
+const ServiceCardContent = (prop: {
+  serviceObject: serviceData;
+  className?: string;
+}) => {
   return (
     <CardContent>
-      <Typography gutterBottom variant="h6" component="div">
+      <Typography
+        gutterBottom
+        variant="h6"
+        component="div"
+        className={prop.className}
+        sx={styles}
+      >
         {prop.serviceObject.name}
       </Typography>
+      {prop.className === 'modal-service-title' && (
+        <Typography>{`Rodzaj zabiegu: ${prop.serviceObject.type}`}</Typography>
+      )}
       <Stack direction="row" spacing={2} sx={{ paddingBottom: '10px' }}>
         <Stack spacing={0.8} direction="row" sx={{ alignItems: 'center' }}>
           <AccessTimeIcon sx={{ color: 'text.disabled' }} aria-hidden="true" />

--- a/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardContent.tsx
@@ -2,29 +2,21 @@ import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import { CardContent, Stack, Typography } from '@mui/material';
 
+import { contentContainerStyles, contentTextStyles } from './ServiceCardStyles';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
-
-const styles = {
-  '&.modal-service': {
-    padding: '0.3125rem',
-    '@media screen and (min-width: 1200px)': {
-      fontSize: '2rem',
-    },
-  },
-};
 
 const ServiceCardContent = (prop: {
   serviceObject: serviceData;
   className?: string;
 }) => {
   return (
-    <CardContent className={prop.className} sx={styles}>
+    <CardContent className={prop.className} sx={contentContainerStyles}>
       <Typography
         gutterBottom
         variant="h6"
         component="div"
         className={prop.className}
-        sx={styles}
+        sx={contentContainerStyles}
       >
         {prop.serviceObject.name}
       </Typography>
@@ -43,7 +35,7 @@ const ServiceCardContent = (prop: {
             variant="subtitle2"
             component="div"
             color="text.disabled"
-            sx={{ ...styles, alignSelf: 'end' }}
+            sx={{ ...contentContainerStyles, alignSelf: 'end' }}
             className={prop.className}
           >
             {`${prop.serviceObject.duration} h`}
@@ -58,14 +50,19 @@ const ServiceCardContent = (prop: {
             variant="subtitle2"
             component="div"
             color="text.disabled"
-            sx={{ ...styles, alignSelf: 'end' }}
+            sx={{ ...contentContainerStyles, alignSelf: 'end' }}
             className={prop.className}
           >
             {`${prop.serviceObject.price} zł`}
           </Typography>
         </Stack>
       </Stack>
-      <Typography variant="body2" color="text.secondary">
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        className={prop.className}
+        sx={contentTextStyles}
+      >
         {prop.serviceObject.description}
       </Typography>
     </CardContent>

--- a/src/Components/Organisms/ServiceCard/ServiceCardStyles.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardStyles.tsx
@@ -1,0 +1,110 @@
+// ServiceCard
+
+export const cardStyles = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: 'fit-content',
+  '@media screen and (min-width: 900px)': {
+    height: '28.125rem',
+  },
+};
+
+// ServiceCardContent
+
+export const contentContainerStyles = {
+  '&.modal-service': {
+    padding: '0.3125rem',
+    '@media screen and (min-width: 1200px)': {
+      fontSize: '2rem',
+    },
+  },
+};
+
+export const contentTextStyles = {
+  '@media screen and (min-width: 900px)': {
+    maxHeight: '80px',
+    overflow: 'hidden',
+    position: 'relative',
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      height: '40px',
+      bottom: '0',
+      right: '0',
+      width: '100%',
+      background:
+        'linear-gradient(0deg, white, rgba(255, 255, 255, 0.6)) no-repeat',
+    },
+    '&.modal-service': {
+      maxHeight: 'none',
+      '&::before': {
+        content: '""',
+        height: '0px',
+      },
+    },
+  },
+};
+
+// ServiceCardActions
+
+export const btnStyles = {
+  borderRadius: '3.125rem',
+  minWidth: '12.5rem',
+  paddingTop: '0.5625rem',
+};
+
+export const btnsPosition = {
+  marginTop: 'auto',
+  justifyContent: 'flex-end',
+  '@media screen and (max-width: 600px)': {
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingBottom: '0.625rem',
+    gap: '0.625rem',
+  },
+  '&.modal-service-details': {
+    justifyContent: 'center',
+    padding: '0 2.125rem',
+  },
+};
+
+// Service Card Modal
+
+export const modalContainerStyles = {
+  maxWidth: '38.75rem',
+  height: 'fit-content',
+  maxHeight: '100%',
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  backgroundColor: 'white',
+  borderRadius: '1rem',
+  padding: '1.875rem',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  gap: '0.3125rem',
+  '@media screen and (max-width: 800px)': {
+    padding: '1rem',
+  },
+};
+
+export const avatarStyles = {
+  height: '9.375rem',
+  width: '9.375rem',
+  margin: '0 1.25rem',
+  alignSelf: 'center',
+  '@media screen and (max-width: 1200px)': {
+    height: '7.1875rem',
+    width: '7.1875rem',
+    margin: '1rem 0 1.5rem',
+  },
+};
+
+export const modalShortBioStyles = {
+  maxHeight: '9.375rem',
+  overflow: 'auto',
+  padding: '0.3125rem',
+};

--- a/src/Components/Organisms/ServiceCard/ServiceCardStyles.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardStyles.tsx
@@ -72,7 +72,8 @@ export const btnsPosition = {
 // Service Card Modal
 
 export const modalContainerStyles = {
-  maxWidth: '38.75rem',
+  maxWidth: '41.75rem',
+  width: '80%',
   height: 'fit-content',
   maxHeight: '100%',
   position: 'absolute',

--- a/src/Components/Organisms/ServiceCard/ServiceCardStyles.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceCardStyles.tsx
@@ -72,8 +72,8 @@ export const btnsPosition = {
 // Service Card Modal
 
 export const modalContainerStyles = {
-  maxWidth: '41.75rem',
-  width: '80%',
+  maxWidth: '46rem',
+  width: '85%',
   height: 'fit-content',
   maxHeight: '100%',
   position: 'absolute',

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -1,6 +1,8 @@
 import { Box } from '@mui/system';
 import { Modal, Typography } from '@mui/material';
 
+import ClosingIcon from './ClosingIcon';
+
 const containerStyles = {
   width: '700px',
   height: '85vh',
@@ -24,6 +26,7 @@ const ServiceDetailsModal = (prop: {
       aria-describedby="modal-more-service-data"
     >
       <Box sx={containerStyles}>
+        <ClosingIcon handleCloseDetails={prop.handleCloseDetails} />
         <Typography id="modal-modal-title" variant="h6" component="h2">
           MODAL MOCK DETAILS
         </Typography>

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -119,7 +119,7 @@ const ServiceDetailsModal = (prop: {
               align="justify"
               sx={{
                 maxHeight: '9.375rem',
-                overflow: 'scroll',
+                overflow: 'auto',
                 padding: '0.3125rem',
               }}
             >

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -1,27 +1,58 @@
+import { Avatar, Modal, Stack, Typography } from '@mui/material';
 import { Box } from '@mui/system';
-import { Modal } from '@mui/material';
+import { useEffect, useState } from 'react';
 
 import ClosingIcon from './ClosingIcon';
+import ServiceCardActions from './ServiceCardActions';
 import ServiceCardContent from './ServiceCardContent';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
 const containerStyles = {
-  width: '620px',
-  height: '85vh',
+  width: '38.75rem',
+  height: 'fit-content',
   position: 'absolute',
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
   backgroundColor: 'white',
   borderRadius: '1rem',
-  padding: '30px',
+  padding: '1.875rem',
 };
 
 const ServiceDetailsModal = (prop: {
   openDetails: boolean;
   handleCloseDetails: () => void;
   serviceObject: serviceData;
+  handleOpen: () => void;
 }) => {
+  // TODO: find solution to put different type than for image
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [imgUrl, setImgUrl] = useState<any | null>(null);
+
+  useEffect(() => {
+    const getTherapistImg = async () => {
+      try {
+        const response = await fetch(
+          prop.serviceObject.therapist.therapistImage,
+        );
+        if (!response.ok) {
+          throw new Error();
+        } else {
+          const imageBlob = await response.blob();
+          const reader = new FileReader();
+          reader.readAsDataURL(imageBlob);
+          reader.onloadend = () => {
+            const base64data = reader.result;
+            setImgUrl(base64data);
+          };
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    getTherapistImg();
+  }, []);
+
   return (
     <Modal
       open={prop.openDetails}
@@ -33,7 +64,44 @@ const ServiceDetailsModal = (prop: {
         <ClosingIcon handleCloseDetails={prop.handleCloseDetails} />
         <ServiceCardContent
           serviceObject={prop.serviceObject}
-          className="modal-service-title"
+          className="modal-service"
+        />
+        <Stack flexDirection="row" sx={{ paddingTop: '2.5rem' }}>
+          <Avatar
+            sx={{
+              height: '9.375rem',
+              width: '9.375rem',
+              margin: '0 1.25rem',
+              alignSelf: 'center',
+            }}
+            src={imgUrl}
+            alt={prop.serviceObject.therapist.therapistAltText}
+          />
+          <Stack>
+            <Typography
+              gutterBottom
+              variant="subtitle2"
+              component="div"
+              fontSize="1rem"
+            >
+              {`Terapeuta:  ${prop.serviceObject.therapist.firstname} ${prop.serviceObject.therapist.surname}`}
+            </Typography>
+            <Typography
+              paragraph
+              color="text.secondary"
+              gutterBottom
+              variant="subtitle2"
+              component="div"
+              align="justify"
+            >
+              {prop.serviceObject.therapist.shortBio}
+            </Typography>
+          </Stack>
+        </Stack>
+        <ServiceCardActions
+          className="modal-service-details"
+          handleOpen={prop.handleOpen}
+          handleOpenDetails={() => console.log()}
         />
       </Box>
     </Modal>

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/system';
+import { Modal, Typography } from '@mui/material';
+
+const ServiceDetailsModal = (prop: {
+  openDetails: boolean;
+  handleCloseDetails: () => void;
+}) => {
+  return (
+    <Modal
+      open={prop.openDetails}
+      onClose={prop.handleCloseDetails}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <Box>
+        <Typography id="modal-modal-title" variant="h6" component="h2">
+          MODAL MOCK DETAILS
+        </Typography>
+        <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+          MODAL MOCK DETAILS
+        </Typography>
+      </Box>
+    </Modal>
+  );
+};
+
+export default ServiceDetailsModal;

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -12,7 +12,17 @@ const ServiceDetailsModal = (prop: {
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
     >
-      <Box>
+      <Box
+        sx={{
+          width: 300,
+          height: 300,
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          backgroundColor: 'white',
+        }}
+      >
         <Typography id="modal-modal-title" variant="h6" component="h2">
           MODAL MOCK DETAILS
         </Typography>

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -5,27 +5,12 @@ import { useEffect, useState } from 'react';
 import ClosingIcon from './ClosingIcon';
 import ServiceCardActions from './ServiceCardActions';
 import ServiceCardContent from './ServiceCardContent';
+import {
+  avatarStyles,
+  modalContainerStyles,
+  modalShortBioStyles,
+} from './ServiceCardStyles';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
-
-const containerStyles = {
-  maxWidth: '38.75rem',
-  height: 'fit-content',
-  maxHeight: '100%',
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  backgroundColor: 'white',
-  borderRadius: '1rem',
-  padding: '1.875rem',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  gap: '0.3125rem',
-  '@media screen and (max-width: 800px)': {
-    padding: '1rem',
-  },
-};
 
 const ServiceDetailsModal = (prop: {
   openDetails: boolean;
@@ -36,7 +21,7 @@ const ServiceDetailsModal = (prop: {
   // TODO: find solution to put different type than for image
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [imgUrl, setImgUrl] = useState<any | null>(null);
-  const matches = useMediaQuery('(min-width:800px)');
+  const matchesMedia = useMediaQuery('(min-width:800px)');
 
   useEffect(() => {
     const getTherapistImg = async () => {
@@ -69,7 +54,7 @@ const ServiceDetailsModal = (prop: {
       aria-labelledby="modal-service-details"
       aria-describedby="modal-more-service-data"
     >
-      <Box sx={containerStyles}>
+      <Box sx={modalContainerStyles}>
         <ClosingIcon handleCloseDetails={prop.handleCloseDetails} />
         <ServiceCardContent
           serviceObject={prop.serviceObject}
@@ -84,19 +69,9 @@ const ServiceDetailsModal = (prop: {
             },
           }}
         >
-          {matches && (
+          {matchesMedia && (
             <Avatar
-              sx={{
-                height: '9.375rem',
-                width: '9.375rem',
-                margin: '0 1.25rem',
-                alignSelf: 'center',
-                '@media screen and (max-width: 1200px)': {
-                  height: '7.1875rem',
-                  width: '7.1875rem',
-                  margin: '1rem 0 1.5rem',
-                },
-              }}
+              sx={avatarStyles}
               src={imgUrl}
               alt={prop.serviceObject.therapist.therapistAltText}
             />
@@ -116,12 +91,7 @@ const ServiceDetailsModal = (prop: {
               gutterBottom
               variant="subtitle2"
               component="div"
-              align="justify"
-              sx={{
-                maxHeight: '9.375rem',
-                overflow: 'auto',
-                padding: '0.3125rem',
-              }}
+              sx={modalShortBioStyles}
             >
               {prop.serviceObject.therapist.shortBio}
             </Typography>

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -1,10 +1,12 @@
 import { Box } from '@mui/system';
-import { Modal, Typography } from '@mui/material';
+import { Modal } from '@mui/material';
 
 import ClosingIcon from './ClosingIcon';
+import ServiceCardContent from './ServiceCardContent';
+import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
 const containerStyles = {
-  width: '700px',
+  width: '620px',
   height: '85vh',
   position: 'absolute',
   top: '50%',
@@ -12,11 +14,13 @@ const containerStyles = {
   transform: 'translate(-50%, -50%)',
   backgroundColor: 'white',
   borderRadius: '1rem',
+  padding: '30px',
 };
 
 const ServiceDetailsModal = (prop: {
   openDetails: boolean;
   handleCloseDetails: () => void;
+  serviceObject: serviceData;
 }) => {
   return (
     <Modal
@@ -27,12 +31,10 @@ const ServiceDetailsModal = (prop: {
     >
       <Box sx={containerStyles}>
         <ClosingIcon handleCloseDetails={prop.handleCloseDetails} />
-        <Typography id="modal-modal-title" variant="h6" component="h2">
-          MODAL MOCK DETAILS
-        </Typography>
-        <Typography id="modal-modal-description" sx={{ mt: 2 }}>
-          MODAL MOCK DETAILS
-        </Typography>
+        <ServiceCardContent
+          serviceObject={prop.serviceObject}
+          className="modal-service-title"
+        />
       </Box>
     </Modal>
   );

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -1,6 +1,17 @@
 import { Box } from '@mui/system';
 import { Modal, Typography } from '@mui/material';
 
+const containerStyles = {
+  width: '700px',
+  height: '85vh',
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  backgroundColor: 'white',
+  borderRadius: '1rem',
+};
+
 const ServiceDetailsModal = (prop: {
   openDetails: boolean;
   handleCloseDetails: () => void;
@@ -9,20 +20,10 @@ const ServiceDetailsModal = (prop: {
     <Modal
       open={prop.openDetails}
       onClose={prop.handleCloseDetails}
-      aria-labelledby="modal-modal-title"
-      aria-describedby="modal-modal-description"
+      aria-labelledby="modal-service-details"
+      aria-describedby="modal-more-service-data"
     >
-      <Box
-        sx={{
-          width: 300,
-          height: 300,
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          backgroundColor: 'white',
-        }}
-      >
+      <Box sx={containerStyles}>
         <Typography id="modal-modal-title" variant="h6" component="h2">
           MODAL MOCK DETAILS
         </Typography>

--- a/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
+++ b/src/Components/Organisms/ServiceCard/ServiceDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Modal, Stack, Typography } from '@mui/material';
+import { Avatar, Modal, Stack, Typography, useMediaQuery } from '@mui/material';
 import { Box } from '@mui/system';
 import { useEffect, useState } from 'react';
 
@@ -8,8 +8,9 @@ import ServiceCardContent from './ServiceCardContent';
 import { serviceData } from '../../PagesBody/LandingPage/LandingPage';
 
 const containerStyles = {
-  width: '38.75rem',
+  maxWidth: '38.75rem',
   height: 'fit-content',
+  maxHeight: '100%',
   position: 'absolute',
   top: '50%',
   left: '50%',
@@ -17,6 +18,13 @@ const containerStyles = {
   backgroundColor: 'white',
   borderRadius: '1rem',
   padding: '1.875rem',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  gap: '0.3125rem',
+  '@media screen and (max-width: 800px)': {
+    padding: '1rem',
+  },
 };
 
 const ServiceDetailsModal = (prop: {
@@ -28,6 +36,7 @@ const ServiceDetailsModal = (prop: {
   // TODO: find solution to put different type than for image
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [imgUrl, setImgUrl] = useState<any | null>(null);
+  const matches = useMediaQuery('(min-width:800px)');
 
   useEffect(() => {
     const getTherapistImg = async () => {
@@ -66,23 +75,38 @@ const ServiceDetailsModal = (prop: {
           serviceObject={prop.serviceObject}
           className="modal-service"
         />
-        <Stack flexDirection="row" sx={{ paddingTop: '2.5rem' }}>
-          <Avatar
-            sx={{
-              height: '9.375rem',
-              width: '9.375rem',
-              margin: '0 1.25rem',
-              alignSelf: 'center',
-            }}
-            src={imgUrl}
-            alt={prop.serviceObject.therapist.therapistAltText}
-          />
+        <Stack
+          flexDirection={{ sm: 'column', lg: 'row' }}
+          sx={{
+            paddingTop: '2rem',
+            '@media screen and (max-width: 1200px)': {
+              paddingTop: '0',
+            },
+          }}
+        >
+          {matches && (
+            <Avatar
+              sx={{
+                height: '9.375rem',
+                width: '9.375rem',
+                margin: '0 1.25rem',
+                alignSelf: 'center',
+                '@media screen and (max-width: 1200px)': {
+                  height: '7.1875rem',
+                  width: '7.1875rem',
+                  margin: '1rem 0 1.5rem',
+                },
+              }}
+              src={imgUrl}
+              alt={prop.serviceObject.therapist.therapistAltText}
+            />
+          )}
           <Stack>
             <Typography
-              gutterBottom
               variant="subtitle2"
               component="div"
               fontSize="1rem"
+              sx={{ padding: '0.3125rem' }}
             >
               {`Terapeuta:  ${prop.serviceObject.therapist.firstname} ${prop.serviceObject.therapist.surname}`}
             </Typography>
@@ -93,6 +117,11 @@ const ServiceDetailsModal = (prop: {
               variant="subtitle2"
               component="div"
               align="justify"
+              sx={{
+                maxHeight: '9.375rem',
+                overflow: 'scroll',
+                padding: '0.3125rem',
+              }}
             >
               {prop.serviceObject.therapist.shortBio}
             </Typography>

--- a/src/Components/PagesBody/LandingPage/LandingPage.tsx
+++ b/src/Components/PagesBody/LandingPage/LandingPage.tsx
@@ -7,7 +7,7 @@ const serviceDataMock = [
     name: 'Masaż Gorącymi Kamieniami',
     type: 'Masaż',
     description:
-      'Odpręż się chłopie, to tutaj znajdziesz ukojenie. Zapomnij o troskach, zapomnij o brzemieniu.. Połóż się i nie myśl o niczym. Odpocznij,',
+      'Odpręż się chłopie, to tutaj znajdziesz ukojenie. Zapomnij o troskach, zapomnij o brzemieniu.. Połóż się i nie myśl o niczym. Odpocznij loremLorem ipsum dolor sit amet consectetur adipisicing elit.',
     price: 150,
     duration: 1.5,
     image:

--- a/src/Components/PagesBody/LandingPage/LandingPage.tsx
+++ b/src/Components/PagesBody/LandingPage/LandingPage.tsx
@@ -45,11 +45,9 @@ export interface serviceData {
 }
 
 const LandingPage = () => {
-  const [serviceObject, setServiceObject] = useState<
-    // TODO: type problems
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    serviceData[] | null | any
-  >(null);
+  const [serviceObject, setServiceObject] = useState<serviceData[] | null>(
+    null,
+  );
   useEffect(() => {
     const getServiceObject = async () => {
       try {

--- a/src/Components/PagesBody/LandingPage/LandingPage.tsx
+++ b/src/Components/PagesBody/LandingPage/LandingPage.tsx
@@ -5,6 +5,7 @@ import ResponsiveGrid from '../../Template/Layout/ResponsiveGrid';
 const serviceDataMock = [
   {
     name: 'Masaż Gorącymi Kamieniami',
+    type: 'Masaż',
     description:
       'Odpręż się chłopie, to tutaj znajdziesz ukojenie. Zapomnij o troskach, zapomnij o brzemieniu.. Połóż się i nie myśl o niczym. Odpocznij,',
     price: 150,
@@ -12,6 +13,14 @@ const serviceDataMock = [
     image:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII',
     altText: 'massage with stones',
+    therapist: {
+      firstname: 'Damian',
+      surname: 'Twardoręki',
+      shortBio:
+        'Absolwent Wyższej Szkoły Rehabilitacji w Warszawie. Jako magister fizjoterapii kontynuuje wieloletnią, rodzinną tradycję pomocy osobom z dolegliwościami kręgosłupa. Pasjonat chiropraktyki. Posiada ponad 10-letnie doświadczenie zawodowe, wypracowane w centrach rehabilitacji i odnowy biologicznej. Skutecznie łączy zdobytą wiedzę i doświadczenie, z niezwykłymi umiejętnościami wyczucia tkanki. Do każdego klienta podchodzi indywidualnie, dostosowując technikę zabiegu.',
+      therapistImage:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII',
+    },
   },
 ];
 

--- a/src/Components/PagesBody/LandingPage/LandingPage.tsx
+++ b/src/Components/PagesBody/LandingPage/LandingPage.tsx
@@ -26,6 +26,7 @@ const serviceDataMock = [
 
 export interface serviceData {
   name: string;
+  type: string;
   description: string;
   price: number;
   duration: number;

--- a/src/Components/PagesBody/LandingPage/LandingPage.tsx
+++ b/src/Components/PagesBody/LandingPage/LandingPage.tsx
@@ -20,9 +20,18 @@ const serviceDataMock = [
         'Absolwent Wyższej Szkoły Rehabilitacji w Warszawie. Jako magister fizjoterapii kontynuuje wieloletnią, rodzinną tradycję pomocy osobom z dolegliwościami kręgosłupa. Pasjonat chiropraktyki. Posiada ponad 10-letnie doświadczenie zawodowe, wypracowane w centrach rehabilitacji i odnowy biologicznej. Skutecznie łączy zdobytą wiedzę i doświadczenie, z niezwykłymi umiejętnościami wyczucia tkanki. Do każdego klienta podchodzi indywidualnie, dostosowując technikę zabiegu.',
       therapistImage:
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII',
+      therapistAltText: "Damian's smiling face",
     },
   },
 ];
+
+export interface therapistTypes {
+  firstname: string;
+  surname: string;
+  shortBio: string;
+  therapistImage: string;
+  therapistAltText: string;
+}
 
 export interface serviceData {
   name: string;
@@ -32,12 +41,15 @@ export interface serviceData {
   duration: number;
   image: string;
   altText: string;
+  therapist: therapistTypes;
 }
 
 const LandingPage = () => {
-  const [serviceObject, setServiceObject] = useState<serviceData[] | null>(
-    null,
-  );
+  const [serviceObject, setServiceObject] = useState<
+    // TODO: type problems
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    serviceData[] | null | any
+  >(null);
   useEffect(() => {
     const getServiceObject = async () => {
       try {


### PR DESCRIPTION
`Responsive Modal with logic and styling`

![image](https://user-images.githubusercontent.com/66994199/163211997-847524b2-adeb-4f21-87d9-a9c7b48e7c9c.png)
![image](https://user-images.githubusercontent.com/66994199/163212088-e9567fc9-2b15-433b-9f49-a60ac150a36d.png)
![image](https://user-images.githubusercontent.com/66994199/163212237-48c50adc-4dfc-4d2e-a2d1-799cc98b4c76.png)



## CR checklist


### a11y
- [x] test w lighthouse robiony w trybie incognito
- [x] test a11y  ma wynik powyżej 90% 
- [x] obrazki mają odpowiednie atrybuty alt
- [x] obrazki dekoracyjne mają przypisany atrybut aria-hidden=true
- [x] da się przejść przez aplikację tabem
- [x] da się potwierdzić wybór elementu enterem
- [x] linki wyróżnione są nie tylko przez kolor
- [x] elementy mają przypisaną odpowiednią rolę (atrybut role)
- [x] nagłówki w odpowiedniej kolejności (tylko jedno h1)
- [x] strona ma logiczną kolejność tabów
- [x] element ma odpowiednio oznaczony focus (np. tło, border)
- [x] teksty są czytelne (mają odpowiedni kontrast)
- [x] inputy używają autocomplete gdzie to możliwe
- [x] tekst napisany jest prostym, zrozumiałym językiem (w tym komunikaty dodatkowe, błędy, itd



### inne
- [x] Build/deploy przechodzi
- [x] Kod jest zrozumiały
- [x] Branch działa lokalnie bez błędów
- [x] PR nie popsuł czyjejś pracy (trzeba przeklikać się przez apkę)
- [x] Brak błędów w konsoli
- [x] Nazwa funkcji pokrywa się z nazwą pliku
- [x] Nazwy zmiennych/obiektów jasno mówią czego dotyczą
- [x] lintery nie pokazują błędów
- [x] eslint-disable nie jest na początku pliku (chyba, że jest ważny powód do tego)
- [x] nie ma zbędnych console.log
- [x] sprawdź czy za długi kod da się rozdzielić na moduły
- [x] usunięto zbędne importy i nieużywane zmienne oraz komentarze
- [x] kolejność komponentu: importy, nazwa komponentu, zmienne, funkcje pomocnicze, hooki, jsx
- [x] pr z ui zawiera screen oraz opis co zostało zmienione
- [x] pr ma przypisanego autora
- [x] pliki są umieszczone w odpowiednich folderach, zgodnie z Atomic Design
